### PR TITLE
Enables use_splunk_hec bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,22 @@ Integer: How often to collect metrics, in minutes. Defaults to `5`.
 
 Integer: How long to retain collect metrics, in days. Defaults to `90`.
 
+##### use_splunk_hec
+
+Boolean: Use the splunk_hec endpoint enabled by the puppetlabs/splunk_hec module. Defaults to `false`.
+
+This will require the module `splunk_hec` installed, which can be found here on the Forge [here](https://forge.puppet.com/puppetlabs/splunk_hec) or [here](https://github.com/puppetlabs/puppetlabs-splunk_hec) on github.
+Further setup instructions for using the `splunk_hec` module can be found within the modules own README.md.
+
 ##### metrics_server_info
 
 Struct:
-  metrics_server_type => Enum['influxdb','graphite','splunk_hec'],
+  metrics_server_type => Enum['influxdb','graphite'],
   hostname            => String,
   port                => Optional[Integer],
   db_name             => Optional[String],
 
-Specifies a metrics server to write data to. Currently it supports `influxdb`, `graphite` and `splnk_hec` type servers. The parameters `metrics_server_type` and `hostname` are both required, and `dbname` is required for a `metrics_server_type` of `influxdb`.
+Specifies a metrics server to write data to. Currently it supports `influxdb`and `graphite` type servers. The parameters `metrics_server_type` and `hostname` are both required, and `dbname` is required for a `metrics_server_type` of `influxdb`.
 
 Example:
 ```
@@ -77,8 +84,11 @@ Puppet_metrics_collector::Metrics_server{ 'collectmydataplease':
 }]
 ```
 
-For a `splunk_hec` setup please note that this will require the module `splunk_hec` installed, which can be found here on the Forge [here](https://forge.puppet.com/puppetlabs/splunk_hec) or [here](https://github.com/puppetlabs/puppetlabs-splunk_hec) on github.
-Further setup instructions for using the `splunk_hec` module can be found within the modules own README.md.
+##### override_metrics_command
+
+String: replace the crontab entry entirely for the metric command being used. Defaults to `undef`
+
+If you are using this, you know what you're doing, and will probably have to set these for each class for the services being collected, and not use this top level param at all.
 
 ## Usage
 

--- a/manifests/activemq.pp
+++ b/manifests/activemq.pp
@@ -4,7 +4,9 @@ class puppet_metrics_collector::activemq (
   String        $metrics_ensure       = $puppet_metrics_collector::activemq_metrics_ensure,
   Array[String] $hosts                = $puppet_metrics_collector::activemq_hosts,
   Integer       $port                 = $puppet_metrics_collector::activemq_port,
+  Boolean       $use_splunk_hec       = $::puppet_metrics_collector::use_splunk_hec,
   Optional[Puppet_metrics_collector::Metrics_server] $metrics_server_info = $::puppet_metrics_collector::metrics_server_info,
+  Optional[String]          $override_metrics_command = $::puppet_metrics_collector::override_metrics_command,
 ) {
   $scripts_dir = $::puppet_metrics_collector::scripts_dir
 
@@ -13,6 +15,8 @@ class puppet_metrics_collector::activemq (
     scripts_dir    => $scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
+    override_metrics_command => $override_metrics_command,
+    use_splunk_hec      => $use_splunk_hec,
   }
 
   $additional_metrics = [
@@ -65,6 +69,7 @@ class puppet_metrics_collector::activemq (
     metrics_port        => $port,
     metric_script_file  => 'amq_metrics',
     additional_metrics  => $additional_metrics,
+    use_splunk_hec      => $use_splunk_hec,
     metrics_server_info => $metrics_server_info,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,9 @@ class puppet_metrics_collector (
   Array[String] $activemq_hosts                = puppet_metrics_collector::hosts_with_pe_profile('amq::broker'),
   Integer       $activemq_port                 = 8161,
   Boolean       $symlink_puppet_metrics_collector = true,
+  Boolean       $use_splunk_hec = false,
   Optional[Puppet_metrics_collector::Metrics_server] $metrics_server_info = undef,
+  Optional[String]          $override_metrics_command = undef,
 ) {
   $scripts_dir = "${output_dir}/scripts"
   $bin_dir     = "${output_dir}/bin"

--- a/manifests/orchestrator.pp
+++ b/manifests/orchestrator.pp
@@ -4,13 +4,17 @@ class puppet_metrics_collector::orchestrator (
   String        $metrics_ensure       = $puppet_metrics_collector::orchestrator_metrics_ensure,
   Array[String] $hosts                = $puppet_metrics_collector::orchestrator_hosts,
   Integer       $port                 = $puppet_metrics_collector::orchestrator_port,
+  Boolean       $use_splunk_hec       = $::puppet_metrics_collector::use_splunk_hec,
   Optional[Puppet_metrics_collector::Metrics_server] $metrics_server_info = $::puppet_metrics_collector::metrics_server_info,
+  Optional[String]          $override_metrics_command = $::puppet_metrics_collector::override_metrics_command,
 ) {
   Puppet_metrics_collector::Pe_metric {
     output_dir     => $puppet_metrics_collector::output_dir,
     scripts_dir    => $puppet_metrics_collector::scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
+    override_metrics_command => $override_metrics_command,
+    use_splunk_hec      => $use_splunk_hec,
   }
 
   puppet_metrics_collector::pe_metric { 'orchestrator' :

--- a/manifests/pe_metric.pp
+++ b/manifests/pe_metric.pp
@@ -10,6 +10,7 @@ define puppet_metrics_collector::pe_metric (
   String                    $metric_script_file = 'tk_metrics',
   Array[Hash]               $additional_metrics = [],
   Boolean                   $ssl                = true,
+  Boolean                   $use_splunk_hec     = false,
   Optional[Puppet_metrics_collector::Metrics_server] $metrics_server_info = undef,
   Optional[String]          $override_metrics_command = undef,
 ) {
@@ -65,9 +66,10 @@ define puppet_metrics_collector::pe_metric (
       $metrics_command = $metrics_server_type ? {
         'influxdb' => "${port_metrics_command} --influx-db ${metrics_server_db} > /dev/null",
         'graphite' => "${port_metrics_command} > /dev/null",
-        'splunk_hec' => "${port_metrics_command} | /opt/puppetlabs/bin/puppet splunk_hec --sourcetype puppet:metrics --pe_metrics > /dev/null",
         default    => "${port_metrics_command} > /dev/null",
       }
+    } elsif $use_splunk_hec {
+      $metrics_command = "${metrics_base_command} | /opt/puppetlabs/bin/puppet splunk_hec --sourcetype puppet:metrics --pe_metrics > /dev/null"
     } else {
       $metrics_command = "${metrics_base_command} --no-print"
     }

--- a/manifests/puppetdb.pp
+++ b/manifests/puppetdb.pp
@@ -4,13 +4,17 @@ class puppet_metrics_collector::puppetdb (
   String        $metrics_ensure       = $puppet_metrics_collector::puppetdb_metrics_ensure,
   Array[String] $hosts                = $puppet_metrics_collector::puppetdb_hosts,
   Integer       $port                 = $puppet_metrics_collector::puppetdb_port,
+  Boolean       $use_splunk_hec       = $::puppet_metrics_collector::use_splunk_hec,
   Optional[Puppet_metrics_collector::Metrics_server] $metrics_server_info = $::puppet_metrics_collector::metrics_server_info,
+  Optional[String]          $override_metrics_command = $::puppet_metrics_collector::override_metrics_command,
 ) {
   Puppet_metrics_collector::Pe_metric {
     output_dir     => $puppet_metrics_collector::output_dir,
     scripts_dir    => $puppet_metrics_collector::scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
+    override_metrics_command => $override_metrics_command,
+    use_splunk_hec      => $use_splunk_hec,
   }
 
   $activemq_metrics = [

--- a/manifests/puppetserver.pp
+++ b/manifests/puppetserver.pp
@@ -4,13 +4,17 @@ class puppet_metrics_collector::puppetserver (
   String        $metrics_ensure       = $puppet_metrics_collector::puppetserver_metrics_ensure,
   Array[String] $hosts                = $puppet_metrics_collector::puppetserver_hosts,
   Integer       $port                 = $puppet_metrics_collector::puppetserver_port,
+  Boolean       $use_splunk_hec       = $::puppet_metrics_collector::use_splunk_hec,
   Optional[Puppet_metrics_collector::Metrics_server] $metrics_server_info = $::puppet_metrics_collector::metrics_server_info,
+  Optional[String]          $override_metrics_command = $::puppet_metrics_collector::override_metrics_command,
 ) {
   Puppet_metrics_collector::Pe_metric {
     output_dir     => $puppet_metrics_collector::output_dir,
     scripts_dir    => $puppet_metrics_collector::scripts_dir,
     cron_minute    => "*/${collection_frequency}",
     retention_days => $retention_days,
+    override_metrics_command => $override_metrics_command,
+    use_splunk_hec      => $use_splunk_hec,
   }
 
   if versioncmp($facts['pe_server_version'], '2018.1.0') < 0 {

--- a/types/metrics_server.pp
+++ b/types/metrics_server.pp
@@ -1,5 +1,5 @@
 type Puppet_metrics_collector::Metrics_server = Struct[{
-  metrics_server_type => Enum['influxdb','graphite', 'splunk_hec'],
+  metrics_server_type => Enum['influxdb','graphite'],
   hostname            => String,
   port                => Optional[Integer],
   db_name             => Optional[String],


### PR DESCRIPTION
Since we define all attributes of a splunk server in the splunk_hec module
we will remove it from the type here and just let a user define using a
splunk_hec as a top level toggle.